### PR TITLE
Update deploy-react.yml to download all artifacts matching pattern

### DIFF
--- a/.github/workflows/deploy-react.yml
+++ b/.github/workflows/deploy-react.yml
@@ -21,15 +21,28 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Get latest successful run ID
+        id: get-latest-run-id
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const runs = await github.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'CI',
+              status: 'success',
+              per_page: 1
+            });
+            return runs.data.workflow_runs[0].id;
       - name: Download artifacts
         id: download-artifact
         uses: actions/download-artifact@v4
         with:
-          name: op_survey_results_dynamo
+          name: op_survey_results_*
           path: output
           merge-multiple: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 14674740985
+          run-id: ${{ steps.get-latest-run-id.outputs.result }}
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: output


### PR DESCRIPTION
Update `.github/workflows/deploy-react.yml` to get all artifacts of the pattern `op_survey_results_*` from the latest successful run of the workflow.

* Add a new step to get the latest successful run ID using the `actions/github-script@v6` action.
* Update the `name` field in the `actions/download-artifact@v4` step to `op_survey_results_*`.
* Remove the hardcoded `run-id` and set it dynamically using the output from the new step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/justinchuby/torch-onnx-op-matrix/pull/40?shareId=fcb3a60f-7598-4cac-9770-0fa7a83ba252).